### PR TITLE
Remove session proto in interface

### DIFF
--- a/sdk/src/main/kotlin/io/provenance/scope/sdk/Client.kt
+++ b/sdk/src/main/kotlin/io/provenance/scope/sdk/Client.kt
@@ -4,7 +4,6 @@ import com.google.protobuf.ByteString
 import com.google.protobuf.Message
 import io.provenance.metadata.v1.ScopeResponse
 import io.provenance.scope.ContractEngine
-import io.provenance.metadata.v1.Session as SessionProto
 import io.provenance.scope.contract.annotations.Record
 import io.provenance.scope.contract.annotations.ScopeSpecificationDefinition
 import io.provenance.scope.contract.contracts.ContractHash
@@ -65,7 +64,7 @@ class Client(val inner: SharedClient, val affiliate: Affiliate) {
     // finish this function implementation
     // make resolver that can go from byte array to Message class
 
-    fun<T: P8eContract> newSession(clazz: Class<T>, scope: ScopeResponse, session: SessionProto): Session.Builder {
+    fun<T: P8eContract> newSession(clazz: Class<T>, scope: ScopeResponse): Session.Builder {
         val contractHash = getContractHash(clazz)
         val protoHash = clazz.methods
             .find { Message::class.java.isAssignableFrom(it.returnType) }
@@ -83,7 +82,6 @@ class Client(val inner: SharedClient, val affiliate: Affiliate) {
             .also { it.client = this } // TODO remove when class is moved over
             .setContractSpec(contractSpec)
             .setProvenanceReference(contractRef)
-            .setProposedSession(session)
             .setScope(scope)
             .addParticipant(affiliate.partyType, affiliate.encryptionKeyRef.publicKey.toPublicKeyProtoOS())
     }

--- a/sdk/src/main/kotlin/io/provenance/scope/sdk/ExecutionResult.kt
+++ b/sdk/src/main/kotlin/io/provenance/scope/sdk/ExecutionResult.kt
@@ -16,7 +16,6 @@ import io.provenance.scope.objectstore.util.base64Decode
 import io.provenance.scope.objectstore.util.toUuid
 import io.provenance.scope.util.MetadataAddress
 import io.provenance.scope.util.toByteString
-import java.util.UUID
 
 sealed class ExecutionResult
 class SignedResult(session: Session, val envelope: Envelope, private val mainNet: Boolean) : ExecutionResult() {
@@ -60,7 +59,7 @@ class SignedResult(session: Session, val envelope: Envelope, private val mainNet
             )
         }
 
-        if (session.proposedSession == null) {
+        if (session.scope?.sessionsList?.find { it.sessionIdInfo.sessionId.toByteArray().toUuid() == session.sessionUuid } == null) {
             val msgWriteSessionRequest = MsgWriteSessionRequest.newBuilder()
                 .apply {
                     sessionBuilder.setSessionId(sessionId)

--- a/sdk/src/main/kotlin/io/provenance/scope/sdk/SessionBuilder.kt
+++ b/sdk/src/main/kotlin/io/provenance/scope/sdk/SessionBuilder.kt
@@ -19,14 +19,12 @@ import io.provenance.scope.sdk.extensions.uuid
 import io.provenance.scope.util.toProtoUuidProv
 import io.provenance.scope.objectstore.util.base64EncodeString
 import io.provenance.scope.objectstore.util.sha256
-import io.provenance.scope.util.MetadataAddress
 import io.provenance.scope.util.toUuidProv
 import org.slf4j.LoggerFactory
 import java.util.*
 import java.util.UUID.randomUUID
 
 class Session(
-    val proposedSession: Session?,
     val participants: HashMap<Specifications.PartyType, PublicKeys.PublicKey>,
     val proposedRecords: HashMap<String, Message>,
     val client: Client, // TODO (wyatt) should probably move this class into the client so we have access to the
@@ -40,7 +38,6 @@ class Session(
     val stagedProposedProtos: MutableList<Message> = mutableListOf(),
 ) {
     private constructor(builder: Builder) : this(
-        builder.proposedSession,
         builder.participants,
         builder.proposedRecords,
         builder.client!!,
@@ -54,8 +51,6 @@ class Session(
     )
 
     class Builder(val scopeSpecUuid: java.util.UUID) {
-        var proposedSession: Session? = null
-            private set
         var proposedRecords: HashMap<String, Message> = HashMap()
             private set
         var participants: HashMap<Specifications.PartyType, PublicKeys.PublicKey> = HashMap()
@@ -81,15 +76,7 @@ class Session(
         }
 
         fun setSessionUuid(sessionUuid: java.util.UUID) = apply {
-            if (proposedSession != null) {
-                throw IllegalStateException("Session UUID cannot be set once the proposed session is already set")
-            }
             this.sessionUuid = sessionUuid
-        }
-
-        fun setProposedSession(session: Session) = apply {
-            this.proposedSession = session
-            this.sessionUuid = session.sessionId.toByteArray().let { MetadataAddress.fromBytes(it) }.getSecondaryUuid()
         }
 
         fun setContractSpec(contractSpec: Specifications.ContractSpec) = apply {

--- a/sdk/src/test/kotlin/SessionBuilderTestHelper.kt.kt
+++ b/sdk/src/test/kotlin/SessionBuilderTestHelper.kt.kt
@@ -8,7 +8,6 @@ import io.provenance.scope.contract.proto.Specifications
 import io.provenance.scope.encryption.model.DirectKeyRef
 import io.provenance.scope.encryption.util.toJavaPrivateKey
 import io.provenance.scope.encryption.util.toJavaPublicKey
-import io.provenance.scope.objectstore.util.toByteArray
 import io.provenance.scope.sdk.*
 import io.provenance.scope.sdk.Session
 import io.provenance.scope.util.MetadataAddress
@@ -70,11 +69,8 @@ fun createSessionBuilderNoRecords(osClient: Client, existingScope: ScopeResponse
         .setContractSpec(spec.build())
         .setProvenanceReference(provenanceReference)
         .setClient(osClient)
+        .setSessionUuid(UUID.randomUUID())
         .apply {
-            val proposedSession = io.provenance.metadata.v1.Session.newBuilder()
-                .setSessionId(MetadataAddress.forSession(scopeUuid, UUID.randomUUID()).bytes.toByteString())
-                .build()
-            setProposedSession(proposedSession)
             if (existingScope != null) {
                 setScope(existingScope)
             }

--- a/sdk/src/test/kotlin/TestSessionBuilder.kt
+++ b/sdk/src/test/kotlin/TestSessionBuilder.kt
@@ -1,16 +1,12 @@
 package io.provenance.p8e.testframework
 
 import com.google.protobuf.ByteString
-import com.google.protobuf.Message
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.*
 import io.provenance.scope.contract.proto.*
 import io.provenance.scope.encryption.ecies.ECUtils
 import io.provenance.scope.sdk.Session
-import io.provenance.scope.sdk.Client
-import java.lang.RuntimeException
-import java.util.*
 
 class UtilsTest : WordSpec({
 


### PR DESCRIPTION
Remove session proto in update existing scope interface. Move to using the session uuid that's set instead. This should be more ergonomic for a user.