### PR TITLE
Cleanup affiliate to signer interface.

### DIFF
--- a/encryption/src/main/kotlin/io/provenance/scope/encryption/model/Key.kt
+++ b/encryption/src/main/kotlin/io/provenance/scope/encryption/model/Key.kt
@@ -1,5 +1,8 @@
 package io.provenance.scope.encryption.model
 
+import io.provenance.scope.encryption.crypto.Pen
+import io.provenance.scope.encryption.crypto.SignerImpl
+import java.security.KeyPair
 import java.security.PrivateKey
 import java.security.PublicKey
 import java.util.UUID
@@ -7,3 +10,9 @@ import java.util.UUID
 sealed class KeyRef(val publicKey: PublicKey)
 class SmartKeyRef(publicKey: PublicKey, val uuid: UUID) : KeyRef(publicKey)
 class DirectKeyRef(publicKey: PublicKey, val privateKey: PrivateKey) : KeyRef(publicKey)
+
+// TODO implement smart key leg
+fun KeyRef.signer(): SignerImpl = when (this) {
+    is DirectKeyRef -> Pen(KeyPair(this.publicKey, this.privateKey))
+    is SmartKeyRef -> throw IllegalStateException("TODO SmartKeyRef is not yet supported!")
+}

--- a/engine/src/main/kotlin/io/provenance/scope/ContractEngine.kt
+++ b/engine/src/main/kotlin/io/provenance/scope/ContractEngine.kt
@@ -16,9 +16,9 @@ import io.provenance.scope.contract.proto.Contracts.ExecutionResult.Result.SKIP
 import io.provenance.scope.contract.proto.Envelopes.Envelope
 import io.provenance.scope.contract.proto.Specifications.ContractSpec
 import io.provenance.scope.definition.DefinitionService
-import io.provenance.scope.encryption.crypto.SignerFactory
 import io.provenance.scope.encryption.ecies.ECUtils
 import io.provenance.scope.encryption.model.KeyRef
+import io.provenance.scope.encryption.model.signer
 import io.provenance.scope.encryption.proto.Common
 import io.provenance.scope.objectstore.client.CachedOsClient
 import io.provenance.scope.objectstore.util.base64Decode
@@ -37,7 +37,6 @@ fun PublicKey.toHex() = toPublicKeyProtoOS().toByteArray().toHexString()
 
 class ContractEngine(
     private val osClient: CachedOsClient,
-    private val signerFactory: SignerFactory,
 ) {
     private val log = LoggerFactory.getLogger(this::class.java);
 
@@ -85,7 +84,7 @@ class ContractEngine(
         spec: ContractSpec
     ): Envelope {
         val definitionService = DefinitionService(osClient, memoryClassLoader)
-        val signer = signerFactory.getSigner(signingKeyRef)
+        val signer = signingKeyRef.signer()
 
         // Load contract spec class
         val contractSpecClass = try {

--- a/examples/app/src/main/kotlin/io/provenance/scope/examples/app/UpdateAndIndexContract.kt
+++ b/examples/app/src/main/kotlin/io/provenance/scope/examples/app/UpdateAndIndexContract.kt
@@ -247,7 +247,7 @@ fun main(args: Array<String>) {
 
         // The proto indexer provides a way to filter the full scope down to a JSON representation
         // that can be stored efficiently in a downstream system for lookups.
-        val result = sdk.inner.indexer.indexFields(
+        val result = sdk.indexer.indexFields(
             scopeResponseThree,
             keyPairs = listOf(KeyPair(affiliate.encryptionKeyRef.publicKey, (affiliate.encryptionKeyRef as DirectKeyRef).privateKey))
         )

--- a/sdk/src/main/kotlin/io/provenance/scope/sdk/Client.kt
+++ b/sdk/src/main/kotlin/io/provenance/scope/sdk/Client.kt
@@ -12,7 +12,6 @@ import io.provenance.scope.contract.proto.ProtoHash
 import io.provenance.scope.contract.proto.PublicKeys
 import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.contract.spec.P8eScopeSpecification
-import io.provenance.scope.encryption.crypto.SignerFactory
 import io.provenance.scope.encryption.ecies.ECUtils
 import io.provenance.scope.objectstore.client.CachedOsClient
 import io.provenance.scope.objectstore.client.OsClient
@@ -22,26 +21,20 @@ import io.provenance.scope.sdk.extensions.isSigned
 import io.provenance.scope.sdk.extensions.resultHash
 import io.provenance.scope.sdk.extensions.resultType
 import io.provenance.scope.sdk.extensions.uuid
-import io.provenance.scope.util.toByteString
 import io.provenance.scope.util.toUuidProv
 import org.slf4j.LoggerFactory
 import java.io.Closeable
 import java.util.ServiceLoader
-import java.util.UUID
 import java.security.PublicKey
 import java.util.concurrent.TimeUnit
 
 // TODO (@steve)
-// how does signer fit in?
 // add error handling and start with extensions present here
 // make resolver that can go from byte array to Message class
 
-class SharedClient(val config: ClientConfig, val signerFactory: SignerFactory = SignerFactory()) : Closeable {
+class SharedClient(val config: ClientConfig) : Closeable {
     val osClient: CachedOsClient = CachedOsClient(OsClient(config.osGrpcUrl, config.osGrpcDeadlineMs), config.osDecryptionWorkerThreads, config.osConcurrencySize, config.cacheRecordSizeInBytes)
-
-    val contractEngine: ContractEngine = ContractEngine(osClient, signerFactory)
-
-    val indexer: ProtoIndexer = ProtoIndexer(osClient, config.mainNet)
+    val contractEngine: ContractEngine = ContractEngine(osClient)
 
     override fun close() {
         osClient.osClient.close()
@@ -55,6 +48,8 @@ class SharedClient(val config: ClientConfig, val signerFactory: SignerFactory = 
 class Client(val inner: SharedClient, val affiliate: Affiliate) {
 
     private val log = LoggerFactory.getLogger(this::class.java);
+
+    val indexer: ProtoIndexer = ProtoIndexer(inner.osClient, inner.config.mainNet, affiliate)
 
     companion object {
         // TODO add a set of affiliates here - every time we create a new Client we should add to it and verify the new affiliate is unique

--- a/sdk/src/main/kotlin/io/provenance/scope/sdk/ProtoIndexer.kt
+++ b/sdk/src/main/kotlin/io/provenance/scope/sdk/ProtoIndexer.kt
@@ -40,7 +40,7 @@ class ProtoIndexer(
     private val messageIndexDescriptor = Index.getDefaultInstance().descriptorForType.file.findExtensionByName("message_index")
     private val affiliateAddress = affiliate.encryptionKeyRef.publicKey.getAddress(mainNet)
 
-    fun indexFields(scope: ScopeResponse, keyPairs: Collection<KeyPair>): Map<String, Any> {
+    fun indexFields(scope: ScopeResponse): Map<String, Any> {
         // find all record groups where there's at least one party member that's an affiliate on this p8e instance
         val sessionMap: Map<ByteString, SessionWrapper> = makeSessionIdMap(scope.sessionsList)
 


### PR DESCRIPTION
Originally, I implemented the SignerFactory thinking we needed it to go from affiliate to a single signer instance. It turns out that it isn't needed.

Also, attempted to cleanup the ProtoIndexer a bit by not passing in the collection of KeyPairs. After thinking about it, I don't know if it makes sense to filter the sessions at all given this is the sdk and not the p8e server? In any case, I changed it to filter on the sole affiliate instead.