### PR TITLE
Use ServiceLoader to determine which classes to load from MemoryClassLoader

### DIFF
--- a/contract-base/build.gradle.kts
+++ b/contract-base/build.gradle.kts
@@ -5,4 +5,19 @@ dependencies {
 
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
+    testImplementation(project(":contract-proto", "testArtifacts"))
+}
+
+val testConfig = configurations.create("testArtifacts") {
+    extendsFrom(configurations["testCompile"])
+}
+
+tasks.register("testJar", Jar::class.java) {
+    dependsOn("testClasses")
+    classifier += "test"
+    from(sourceSets["test"].output)
+}
+
+artifacts {
+    add("testArtifacts", tasks.named<Jar>("testJar") )
 }

--- a/contract-base/src/test/java/io/provenance/scope/contract/JavaContractHash1631912511583.java
+++ b/contract-base/src/test/java/io/provenance/scope/contract/JavaContractHash1631912511583.java
@@ -1,0 +1,28 @@
+package io.provenance.scope.contract;
+
+import io.provenance.scope.contract.contracts.ContractHash;
+
+import java.util.Map;
+import java.util.HashMap;
+
+public class JavaContractHash1631912511583 implements ContractHash {
+
+    private final Map<String, Boolean> classes = new HashMap<String, Boolean>() {{
+        put("io.provenance.scope.contract.TestJavaContracts$TestJavaContract", true);
+    }};
+
+    @Override
+    public Map<String, Boolean> getClasses() {
+        return classes;
+    }
+
+    @Override
+    public String getUuid() {
+        return "1631912511583";
+    }
+
+    @Override
+    public String getHash() {
+        return "bfkvcj/TeXCrhUZ4TJedRP2iIWRggsIg2PZ6gaRCUlg=";
+    }
+}

--- a/contract-base/src/test/java/io/provenance/scope/contract/JavaProtoHash1631912511583.java
+++ b/contract-base/src/test/java/io/provenance/scope/contract/JavaProtoHash1631912511583.java
@@ -1,0 +1,28 @@
+package io.provenance.scope.contract;
+
+import java.util.Map;
+import java.util.HashMap;
+
+import io.provenance.scope.contract.proto.ProtoHash;
+
+public class JavaProtoHash1631912511583 implements ProtoHash {
+
+    private final Map<String, Boolean> classes = new HashMap<String, Boolean>() {{
+        put("io.provenance.scope.contract.proto.TestContractProtos$TestProto", true);
+    }};
+
+    @Override
+    public Map<String, Boolean> getClasses() {
+        return classes;
+    }
+
+    @Override
+    public String getUuid() {
+        return "1631912511583";
+    }
+
+    @Override
+    public String getHash() {
+        return "5+71R7IWzuDVAqeunYtBn0atXySPtXTb9xOGXckKoBo=";
+    }
+}

--- a/contract-base/src/test/java/io/provenance/scope/contract/TestJavaContracts.java
+++ b/contract-base/src/test/java/io/provenance/scope/contract/TestJavaContracts.java
@@ -1,0 +1,25 @@
+package io.provenance.scope.contract;
+
+import io.provenance.scope.contract.annotations.Function;
+import io.provenance.scope.contract.annotations.Input;
+import io.provenance.scope.contract.annotations.Participants;
+import io.provenance.scope.contract.annotations.Record;
+import io.provenance.scope.contract.annotations.ScopeSpecification;
+import io.provenance.scope.contract.annotations.ScopeSpecificationDefinition;
+import io.provenance.scope.contract.proto.Specifications;
+import io.provenance.scope.contract.proto.TestContractProtos;
+import io.provenance.scope.contract.spec.P8eContract;
+import io.provenance.scope.contract.spec.P8eScopeSpecification;
+
+public class TestJavaContracts {
+    @Participants(roles = {Specifications.PartyType.OWNER})
+    public static class TestJavaContract extends P8eContract {
+        @Function(invokedBy = Specifications.PartyType.OWNER)
+        @Record(name = "testRecord")
+        public TestContractProtos.TestProto testRecord() {
+            return TestContractProtos.TestProto.newBuilder()
+                    .setValue("testRecordJavaValue")
+                    .build();
+        }
+    }
+}

--- a/contract-base/src/test/kotlin/io/provenance/scope/contract/TestContract.kt
+++ b/contract-base/src/test/kotlin/io/provenance/scope/contract/TestContract.kt
@@ -1,0 +1,13 @@
+package io.provenance.scope.contract
+
+import io.provenance.scope.contract.annotations.Participants
+import io.provenance.scope.contract.annotations.Record
+import io.provenance.scope.contract.proto.PublicKeys
+import io.provenance.scope.contract.proto.Specifications
+import io.provenance.scope.contract.spec.P8eContract
+
+@Participants([Specifications.PartyType.OWNER])
+class TestContract: P8eContract() {
+    @Record(name = "testRecord")
+    fun testRecord(): PublicKeys.PublicKey = PublicKeys.PublicKey.getDefaultInstance()
+}

--- a/contract-base/src/test/kotlin/io/provenance/scope/contract/TestContract.kt
+++ b/contract-base/src/test/kotlin/io/provenance/scope/contract/TestContract.kt
@@ -4,10 +4,11 @@ import io.provenance.scope.contract.annotations.Participants
 import io.provenance.scope.contract.annotations.Record
 import io.provenance.scope.contract.proto.PublicKeys
 import io.provenance.scope.contract.proto.Specifications
+import io.provenance.scope.contract.proto.TestContractProtos
 import io.provenance.scope.contract.spec.P8eContract
 
 @Participants([Specifications.PartyType.OWNER])
 class TestContract: P8eContract() {
     @Record(name = "testRecord")
-    fun testRecord(): PublicKeys.PublicKey = PublicKeys.PublicKey.getDefaultInstance()
+    fun testRecord(): TestContractProtos.TestProto = TestContractProtos.TestProto.newBuilder().setValue("testRecordValue").build()
 }

--- a/contract-base/src/test/kotlin/io/provenance/scope/contract/TestContractHash.kt
+++ b/contract-base/src/test/kotlin/io/provenance/scope/contract/TestContractHash.kt
@@ -1,0 +1,20 @@
+package io.provenance.scope.contract
+
+import io.provenance.scope.contract.contracts.ContractHash
+
+class TestContractHash : ContractHash {
+
+    private val classes = mapOf("io.provenance.scope.contract.TestContract" to true)
+
+    override fun getClasses(): Map<String, Boolean> {
+        return classes
+    }
+
+    override fun getUuid(): String {
+        return "123456789"
+    }
+
+    override fun getHash(): String {
+        return "Qc2bHdrg+3LxlItTZSbzhJnUn5Btha0LCXaiSk34Hhk="
+    }
+}

--- a/contract-base/src/test/kotlin/io/provenance/scope/contract/TestProtoHash.kt
+++ b/contract-base/src/test/kotlin/io/provenance/scope/contract/TestProtoHash.kt
@@ -1,0 +1,20 @@
+package io.provenance.scope.contract
+
+import io.provenance.scope.contract.proto.ProtoHash
+
+class TestProtoHash : ProtoHash {
+
+    private val classes = mapOf("io.provenance.scope.contract.proto.TestContractProtos.TestProto" to true)
+
+    override fun getClasses(): Map<String, Boolean> {
+        return classes
+    }
+
+    override fun getUuid(): String {
+        return "123456789"
+    }
+
+    override fun getHash(): String {
+        return "M8PWxG2TFfO0YzL3sDW/l9kX325y+3v+5liGcjZoi4Q="
+    }
+}

--- a/contract-base/src/test/kotlin/io/provenance/scope/contract/TestProtoHash.kt
+++ b/contract-base/src/test/kotlin/io/provenance/scope/contract/TestProtoHash.kt
@@ -4,7 +4,7 @@ import io.provenance.scope.contract.proto.ProtoHash
 
 class TestProtoHash : ProtoHash {
 
-    private val classes = mapOf("io.provenance.scope.contract.proto.TestContractProtos.TestProto" to true)
+    private val classes = mapOf("io.provenance.scope.contract.proto.TestContractProtos\$TestProto" to true)
 
     override fun getClasses(): Map<String, Boolean> {
         return classes

--- a/contract-base/src/test/resources/META-INF/services/io.provenance.scope.contract.contracts.ContractHash
+++ b/contract-base/src/test/resources/META-INF/services/io.provenance.scope.contract.contracts.ContractHash
@@ -1,1 +1,2 @@
 io.provenance.scope.contract.TestContractHash
+io.provenance.scope.contract.JavaContractHash1631912511583

--- a/contract-base/src/test/resources/META-INF/services/io.provenance.scope.contract.contracts.ContractHash
+++ b/contract-base/src/test/resources/META-INF/services/io.provenance.scope.contract.contracts.ContractHash
@@ -1,0 +1,1 @@
+io.provenance.scope.contract.TestContractHash

--- a/contract-base/src/test/resources/META-INF/services/io.provenance.scope.contract.proto.ProtoHash
+++ b/contract-base/src/test/resources/META-INF/services/io.provenance.scope.contract.proto.ProtoHash
@@ -1,0 +1,1 @@
+io.provenance.scope.contract.TestProtoHash

--- a/contract-base/src/test/resources/META-INF/services/io.provenance.scope.contract.proto.ProtoHash
+++ b/contract-base/src/test/resources/META-INF/services/io.provenance.scope.contract.proto.ProtoHash
@@ -1,1 +1,2 @@
 io.provenance.scope.contract.TestProtoHash
+io.provenance.scope.contract.JavaProtoHash1631912511583

--- a/contract-proto/src/test/proto/io/provenance/scope/contract/test_contract.proto
+++ b/contract-proto/src/test/proto/io/provenance/scope/contract/test_contract.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package io.provenance.scope.contract;
+
+option java_package = "io.provenance.scope.contract.proto";
+option java_outer_classname = "TestContractProtos";
+
+message TestProto {
+  string value = 1;
+}

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -39,4 +39,5 @@ dependencies {
     implementation("io.arrow-kt", "arrow-core", Version.arrow)
 
     testImplementation(project(":contract-base", "testArtifacts"))
+    testImplementation(project(":contract-proto", "testArtifacts"))
 }

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -37,4 +37,6 @@ dependencies {
     compileOnly("org.slf4j", "log4j-over-slf4j", "1.7.30")
 
     implementation("io.arrow-kt", "arrow-core", Version.arrow)
+
+    testImplementation(project(":contract-base", "testArtifacts"))
 }

--- a/engine/src/main/kotlin/io/provenance/scope/ContractEngine.kt
+++ b/engine/src/main/kotlin/io/provenance/scope/ContractEngine.kt
@@ -26,6 +26,7 @@ import io.provenance.scope.objectstore.util.toHex
 import io.provenance.scope.objectstore.util.toPublicKeyProtoOS
 import io.provenance.scope.util.ContractDefinitionException
 import io.provenance.scope.util.ProtoUtil.proposedRecordOf
+import io.provenance.scope.util.forThread
 import io.provenance.scope.util.scopeOrNull
 import io.provenance.scope.util.toMessageWithStackTrace
 import io.provenance.scope.util.toUuid

--- a/engine/src/main/kotlin/io/provenance/scope/definition/DefinitionService.kt
+++ b/engine/src/main/kotlin/io/provenance/scope/definition/DefinitionService.kt
@@ -7,6 +7,7 @@ import io.provenance.scope.contract.proto.Commons.DefinitionSpec
 import io.provenance.scope.encryption.model.KeyRef
 import io.provenance.scope.objectstore.client.CachedOsClient
 import io.provenance.scope.objectstore.util.base64Decode
+import io.provenance.scope.util.forThread
 import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.lang.reflect.Method

--- a/engine/src/test/kotlin/io/provenance/scope/classloader/MemoryClassLoaderTest.kt
+++ b/engine/src/test/kotlin/io/provenance/scope/classloader/MemoryClassLoaderTest.kt
@@ -2,7 +2,9 @@ package io.provenance.scope.classloader
 
 import io.kotest.core.spec.style.WordSpec
 import io.provenance.scope.contract.TestContract
+import io.provenance.scope.contract.TestJavaContracts
 import io.provenance.scope.contract.proto.PublicKeys
+import io.provenance.scope.contract.proto.TestContractProtos
 import io.provenance.scope.contract.proto.Utils
 import io.provenance.scope.contract.spec.P8eContract
 import java.io.FileInputStream
@@ -34,8 +36,39 @@ class MemoryClassLoaderTest: WordSpec() {
 
                 val publicKeyResultClass = clazz.declaredMethods.find { it.name == "testRecord" }?.returnType
                 assert(publicKeyResultClass != null) { "testRecord method not found on TestContract" }
-                assert(publicKeyResultClass?.name == PublicKeys.PublicKey::class.java.name) { "testRecord return type name does not match" }
-                assert(publicKeyResultClass == PublicKeys.PublicKey::class.java) { "testRecord return type does not match" }
+                assert(publicKeyResultClass?.name == TestContractProtos.TestProto::class.java.name) { "testRecord return type name does not match" }
+                assert(publicKeyResultClass == TestContractProtos.TestProto::class.java) { "testRecord return type does not match" }
+
+                val uuidClass = clazz.superclass.declaredFields.find { it.name == "uuid" }?.type
+                assert(uuidClass != null) { "base P8eContract class uuid field not found" }
+                assert(uuidClass?.name == Utils.UUID::class.java.name) { "base P8eContract uuid type name does not match" }
+                assert(uuidClass == Utils.UUID::class.java) { "base P8eContract uuid type does not match" }
+            }
+            "load P8eContract java classes from child class loader" {
+                val classLoader = TestJavaContracts.TestJavaContract::class
+                    .java
+                    .protectionDomain
+                    .codeSource
+                    .location
+                    .path
+                    .let { FileInputStream(it) }
+                    .use {
+                        MemoryClassLoader(
+                            "some-hash",
+                            it
+                        )
+                    }
+
+                val clazz = classLoader.loadClass(TestJavaContracts.TestJavaContract::class.java.name)
+
+                assert(P8eContract::class.java.isAssignableFrom(clazz)) { "loaded contract class does not inherit from P8eContract" }
+                assert(TestJavaContracts.TestJavaContract::class.java.name == clazz.name) { "loaded contract class name was different than requested" }
+                assert(TestJavaContracts.TestJavaContract::class.java != clazz) { "loaded contract class was the same as system contract class" }
+
+                val publicKeyResultClass = clazz.declaredMethods.find { it.name == "testRecord" }?.returnType
+                assert(publicKeyResultClass != null) { "testRecord method not found on TestContract" }
+                assert(publicKeyResultClass?.name == TestContractProtos.TestProto::class.java.name) { "testRecord return type name does not match" }
+                assert(publicKeyResultClass == TestContractProtos.TestProto::class.java) { "testRecord return type does not match" }
 
                 val uuidClass = clazz.superclass.declaredFields.find { it.name == "uuid" }?.type
                 assert(uuidClass != null) { "base P8eContract class uuid field not found" }

--- a/engine/src/test/kotlin/io/provenance/scope/classloader/MemoryClassLoaderTest.kt
+++ b/engine/src/test/kotlin/io/provenance/scope/classloader/MemoryClassLoaderTest.kt
@@ -1,0 +1,47 @@
+package io.provenance.scope.classloader
+
+import io.kotest.core.spec.style.WordSpec
+import io.provenance.scope.contract.TestContract
+import io.provenance.scope.contract.proto.PublicKeys
+import io.provenance.scope.contract.proto.Utils
+import io.provenance.scope.contract.spec.P8eContract
+import java.io.FileInputStream
+
+
+class MemoryClassLoaderTest: WordSpec() {
+    init {
+        "MemoryClassLoader" should {
+            "load P8eContract classes from child class loader" {
+                val classLoader = TestContract::class
+                    .java
+                    .protectionDomain
+                    .codeSource
+                    .location
+                    .path
+                    .let { FileInputStream(it) }
+                    .use {
+                        MemoryClassLoader(
+                            "some-hash",
+                            it
+                        )
+                    }
+
+                val clazz = classLoader.loadClass(TestContract::class.java.name)
+
+                assert(P8eContract::class.java.isAssignableFrom(clazz)) { "loaded contract class does not inherit from P8eContract" }
+                assert(TestContract::class.java.name == clazz.name) { "loaded contract class name was different than requested" }
+                assert(TestContract::class.java != clazz) { "loaded contract class was the same as system contract class" }
+
+                val publicKeyResultClass = clazz.declaredMethods.find { it.name == "testRecord" }?.returnType
+                assert(publicKeyResultClass != null) { "testRecord method not found on TestContract" }
+                assert(publicKeyResultClass?.name == PublicKeys.PublicKey::class.java.name) { "testRecord return type name does not match" }
+                assert(publicKeyResultClass == PublicKeys.PublicKey::class.java) { "testRecord return type does not match" }
+
+                val uuidClass = clazz.superclass.declaredFields.find { it.name == "uuid" }?.type
+                assert(uuidClass != null) { "base P8eContract class uuid field not found" }
+                assert(uuidClass?.name == Utils.UUID::class.java.name) { "base P8eContract uuid type name does not match" }
+                assert(uuidClass == Utils.UUID::class.java) { "base P8eContract uuid type does not match" }
+            }
+        }
+    }
+}

--- a/util/src/main/kotlin/io/provenance/scope/util/ClassLoaderExtensions.kt
+++ b/util/src/main/kotlin/io/provenance/scope/util/ClassLoaderExtensions.kt
@@ -1,0 +1,11 @@
+package io.provenance.scope.util
+
+fun <T> ClassLoader.forThread(fn: () -> T): T {
+    val current = Thread.currentThread().contextClassLoader
+    try {
+        Thread.currentThread().contextClassLoader = this
+        return fn()
+    } finally {
+        Thread.currentThread().contextClassLoader = current
+    }
+}


### PR DESCRIPTION
Pulled test over from server-side p8e, it had been commented out with a note about needing to use an open source contract library. I was able to just add a test contract and then set up the Contract/ProtoHash classes with a ServiceLoader for test to accomplish the same thing. Additionally, I was able to run this with my local executor and verify that execution is still working.