### PR TITLE
Allow Other KeyRef Implementations

### DIFF
--- a/encryption/src/main/kotlin/io/provenance/scope/encryption/ecies/ProvenanceECIESCipher.kt
+++ b/encryption/src/main/kotlin/io/provenance/scope/encryption/ecies/ProvenanceECIESCipher.kt
@@ -74,7 +74,7 @@ class ProvenanceECIESCipher {
     @Throws(ProvenanceECIESDecryptException::class)
     fun decrypt(payload: ProvenanceECIESCryptogram, keyRef: KeyRef, additionalAuthenticatedData: String?): ByteArray {
         try {
-            val ephemeralDerivedSecretKey = ProvenanceHKDFSHA256.derive(keyRef.getSecretKey(payload), null, ECUtils.KDF_SIZE)
+            val ephemeralDerivedSecretKey = ProvenanceHKDFSHA256.derive(keyRef.getSecretKey(payload.ephemeralPublicKey), null, ECUtils.KDF_SIZE)
 
             // Validate data MAC value
             val encKeyBytes = Arrays.copyOf(ephemeralDerivedSecretKey, 32)

--- a/encryption/src/main/kotlin/io/provenance/scope/encryption/model/Key.kt
+++ b/encryption/src/main/kotlin/io/provenance/scope/encryption/model/Key.kt
@@ -4,6 +4,11 @@ import com.fortanix.sdkms.v1.api.SignAndVerifyApi
 import io.provenance.scope.encryption.crypto.Pen
 import io.provenance.scope.encryption.crypto.SignerImpl
 import io.provenance.scope.encryption.crypto.SmartKeySigner
+import io.provenance.scope.encryption.ecies.ECUtils
+import io.provenance.scope.encryption.ecies.ProvenanceECIESCryptogram
+import io.provenance.scope.encryption.ecies.ProvenanceKeyGenerator
+import io.provenance.scope.encryption.experimental.extensions.toAgreeKey
+import io.provenance.scope.encryption.experimental.extensions.toTransientSecurityObject
 import java.security.KeyPair
 import java.security.PrivateKey
 import java.security.PublicKey
@@ -13,7 +18,12 @@ import java.util.UUID
  * A reference to a key used as an signing/encryption/decryption provider
  * @property [publicKey] the [Public Key][PublicKey] for this reference
  */
-sealed class KeyRef(val publicKey: PublicKey)
+abstract class KeyRef(val publicKey: PublicKey) {
+    /** @return a computed secret key for a given payload */
+    abstract fun getSecretKey(payload: ProvenanceECIESCryptogram): ByteArray
+    /** @return a [SignerImpl] object for a given [KeyRef] */
+    abstract fun signer(): SignerImpl
+}
 
 /**
  * A reference to an externally-held Equinix SmartKey Security Object stored in an HSM
@@ -21,24 +31,38 @@ sealed class KeyRef(val publicKey: PublicKey)
  * @property [uuid] the Security Object uuid
  * @property [signAndVerifyApi] an Equinix SmartKey api instance to provide communication for signing/encryption/decryption operations
  */
-class SmartKeyRef(publicKey: PublicKey, val uuid: UUID, val signAndVerifyApi: SignAndVerifyApi) : KeyRef(publicKey)
+class SmartKeyRef(publicKey: PublicKey, val uuid: UUID, val signAndVerifyApi: SignAndVerifyApi) : KeyRef(publicKey) {
+    override fun getSecretKey(payload: ProvenanceECIESCryptogram): ByteArray {
+        // Create a transient security object out of the ephemeral public key from the payload.
+        val transientEphemeralSObj = payload.ephemeralPublicKey.toTransientSecurityObject()
+
+        // Compute the shared/agree key via SmartKey's API
+        val secretKey = uuid.toString().toAgreeKey(transientEphemeralSObj.transientKey)
+
+        return secretKey.value
+    }
+
+    override fun signer(): SignerImpl = SmartKeySigner(uuid.toString(), publicKey, signAndVerifyApi)
+}
 
 /**
  * A reference to a locally-held key
  * @param [publicKey] the [Public Key][PublicKey] for this reference
  * @property [privateKey] the [Private Key][PrivateKey] for this reference
  */
-class DirectKeyRef(publicKey: PublicKey, val privateKey: PrivateKey) : KeyRef(publicKey)
+class DirectKeyRef(publicKey: PublicKey, private val privateKey: PrivateKey) : KeyRef(publicKey) {
+    constructor(keyPair: KeyPair) : this(keyPair.public, keyPair.private)
+
+    override fun getSecretKey(payload: ProvenanceECIESCryptogram): ByteArray {
+        val secretKey = ProvenanceKeyGenerator.computeSharedKey(privateKey, payload.ephemeralPublicKey)
+
+        return ECUtils.convertSharedSecretKeyToBytes(secretKey)
+    }
+
+    override fun signer(): SignerImpl = Pen(KeyPair(publicKey, privateKey))
+}
 
 /**
  * A single affiliate's keys corresponding to signing and encryption
  */
 data class SigningAndEncryptionPublicKeys(val signingPublicKey: PublicKey, val encryptionPublicKey: PublicKey)
-
-/**
- * @return a [SignerImpl] object for a given [KeyRef]
- */
-fun KeyRef.signer(): SignerImpl = when (this) {
-    is DirectKeyRef -> Pen(KeyPair(this.publicKey, this.privateKey))
-    is SmartKeyRef -> SmartKeySigner(this.uuid.toString(), this.publicKey, this.signAndVerifyApi)
-}

--- a/engine/src/main/kotlin/io/provenance/scope/ContractEngine.kt
+++ b/engine/src/main/kotlin/io/provenance/scope/ContractEngine.kt
@@ -17,7 +17,6 @@ import io.provenance.scope.contract.proto.Specifications.ContractSpec
 import io.provenance.scope.definition.DefinitionService
 import io.provenance.scope.encryption.ecies.ECUtils
 import io.provenance.scope.encryption.model.KeyRef
-import io.provenance.scope.encryption.model.signer
 import io.provenance.scope.objectstore.client.CachedOsClient
 import io.provenance.scope.objectstore.util.base64Decode
 import io.provenance.scope.objectstore.util.toHex

--- a/examples/app/src/main/kotlin/io/provenance/scope/examples/app/utils/Helpers.kt
+++ b/examples/app/src/main/kotlin/io/provenance/scope/examples/app/utils/Helpers.kt
@@ -8,7 +8,6 @@ import io.provenance.metadata.v1.ScopeRequest
 import io.provenance.metadata.v1.ScopeResponse
 import io.provenance.scope.encryption.crypto.SignerImpl
 import io.provenance.scope.encryption.model.KeyRef
-import io.provenance.scope.encryption.model.signer
 import io.provenance.scope.encryption.util.getAddress
 import io.provenance.scope.sdk.SignedResult
 import java.util.UUID

--- a/os-client/src/main/kotlin/io/provenance/scope/objectstore/client/CachedOsClient.kt
+++ b/os-client/src/main/kotlin/io/provenance/scope/objectstore/client/CachedOsClient.kt
@@ -11,7 +11,6 @@ import io.opentracing.Tracer
 import io.opentracing.util.GlobalTracer
 import io.provenance.scope.contract.proto.Specifications.ContractSpec
 import io.provenance.scope.encryption.model.KeyRef
-import io.provenance.scope.encryption.model.signer
 import io.provenance.scope.objectstore.util.base64Encode
 import io.provenance.scope.objectstore.util.base64EncodeString
 import io.provenance.scope.objectstore.util.sha256LoBytes

--- a/os-client/src/test/kotlin/io/provenance/scope/objectstore/client/CachedOsClientTest.kt
+++ b/os-client/src/test/kotlin/io/provenance/scope/objectstore/client/CachedOsClientTest.kt
@@ -25,8 +25,8 @@ import java.util.UUID
 
 class CachedOsClientTest: WordSpec() {
     lateinit var osClient: OsClient
-    val signingKeyRef = ProvenanceKeyGenerator.generateKeyPair().let { DirectKeyRef(it.public, it.private) }
-    val encryptionKeyRef = ProvenanceKeyGenerator.generateKeyPair().let { DirectKeyRef(it.public, it.private) }
+    val signingKeyRef = ProvenanceKeyGenerator.generateKeyPair().let { DirectKeyRef(it) }
+    val encryptionKeyRef = ProvenanceKeyGenerator.generateKeyPair().let { DirectKeyRef(it) }
 
     override fun beforeTest(testCase: TestCase) {
         super.beforeTest(testCase)

--- a/sdk/src/main/kotlin/io/provenance/scope/sdk/Client.kt
+++ b/sdk/src/main/kotlin/io/provenance/scope/sdk/Client.kt
@@ -14,7 +14,6 @@ import io.provenance.scope.proto.PK
 import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.contract.spec.P8eScopeSpecification
 import io.provenance.scope.encryption.ecies.ECUtils
-import io.provenance.scope.encryption.model.signer
 import io.provenance.scope.objectstore.client.CachedOsClient
 import io.provenance.scope.objectstore.client.OsClient
 import io.provenance.scope.sdk.ContractSpecMapper.dehydrateSpec

--- a/sdk/src/main/kotlin/io/provenance/scope/sdk/ProtoIndexer.kt
+++ b/sdk/src/main/kotlin/io/provenance/scope/sdk/ProtoIndexer.kt
@@ -17,7 +17,6 @@ import io.provenance.scope.contract.proto.IndexProto.Index.Behavior.*
 import io.provenance.scope.definition.DefinitionService
 import io.provenance.scope.encryption.crypto.SignerImpl
 import io.provenance.scope.encryption.model.KeyRef
-import io.provenance.scope.encryption.model.signer
 import io.provenance.scope.encryption.util.getAddress
 import io.provenance.scope.objectstore.client.CachedOsClient
 import io.provenance.scope.objectstore.util.base64Decode

--- a/sdk/src/main/kotlin/io/provenance/scope/sdk/mailbox/PollAffiliateMailbox.kt
+++ b/sdk/src/main/kotlin/io/provenance/scope/sdk/mailbox/PollAffiliateMailbox.kt
@@ -4,7 +4,6 @@ import io.provenance.metadata.v1.Scope
 import io.provenance.scope.contract.proto.Envelopes
 import io.provenance.scope.contract.proto.Envelopes.Envelope
 import io.provenance.scope.encryption.model.KeyRef
-import io.provenance.scope.encryption.model.signer
 import io.provenance.scope.encryption.proto.Encryption.Audience
 import io.provenance.scope.encryption.util.getAddress
 import io.provenance.scope.encryption.util.orThrow

--- a/sdk/src/test/kotlin/SessionBuilderTestHelper.kt
+++ b/sdk/src/test/kotlin/SessionBuilderTestHelper.kt
@@ -33,8 +33,8 @@ val recordCacheSizeInBytes = 20000L
 val osGrpcUri = URI.create("https://localhost:5000")
 
 fun createClientDummy(localKeyIndex: Int): Client {
-    val encryptionKeyRef = DirectKeyRef(localKeys[localKeyIndex].public, localKeys[localKeyIndex].private)
-    val signingKeyRef = DirectKeyRef(localKeys[localKeyIndex + 1].public, localKeys[localKeyIndex + 1].private)
+    val encryptionKeyRef = DirectKeyRef(localKeys[localKeyIndex])
+    val signingKeyRef = DirectKeyRef(localKeys[localKeyIndex + 1])
     val partyType = Specifications.PartyType.OWNER
     val affiliate = Affiliate(signingKeyRef, encryptionKeyRef, partyType)
 

--- a/sdk/src/test/kotlin/io/provenance/scope/sdk/ClientTest.kt
+++ b/sdk/src/test/kotlin/io/provenance/scope/sdk/ClientTest.kt
@@ -29,8 +29,8 @@ class ClientTest : WordSpec() {
                 }
 
                 val client = Client(SharedClient(ClientConfig(0, 0, 0, URI.create("http://localhost:5000"), mainNet = false)), Affiliate(
-                    DirectKeyRef(signingKeyPair.public, signingKeyPair.private),
-                    DirectKeyRef(encryptionKeyPair.public, encryptionKeyPair.private),
+                    DirectKeyRef(signingKeyPair),
+                    DirectKeyRef(encryptionKeyPair),
                     Specifications.PartyType.OWNER
                 ))
 

--- a/sdk/src/test/kotlin/io/provenance/scope/sdk/ProtoIndexerTest.kt
+++ b/sdk/src/test/kotlin/io/provenance/scope/sdk/ProtoIndexerTest.kt
@@ -115,8 +115,8 @@ class ProtoIndexerTest: AnnotationSpec(){
     @BeforeAll
     fun setUp(){
         val affiliate = Affiliate(
-            signingKeyRef = DirectKeyRef(keyPair.public, keyPair.private),
-            encryptionKeyRef = DirectKeyRef(keyPair.public, keyPair.private),
+            signingKeyRef = DirectKeyRef(keyPair),
+            encryptionKeyRef = DirectKeyRef(keyPair),
             partyType = OWNER,
         )
         mockDefinitionService = mockk<DefinitionService>()

--- a/sdk/src/test/kotlin/io/provenance/scope/sdk/mailbox/PollAffiliateMailboxTest.kt
+++ b/sdk/src/test/kotlin/io/provenance/scope/sdk/mailbox/PollAffiliateMailboxTest.kt
@@ -18,7 +18,6 @@ import io.provenance.scope.encryption.domain.inputstream.DIMEInputStream
 import io.provenance.scope.encryption.ecies.ProvenanceKeyGenerator
 import io.provenance.scope.encryption.model.DirectKeyRef
 import io.provenance.scope.encryption.model.SigningAndEncryptionPublicKeys
-import io.provenance.scope.encryption.model.signer
 import io.provenance.scope.encryption.proto.Encryption
 import io.provenance.scope.objectstore.client.OsClient
 import io.provenance.scope.sdk.mailbox.ExecutionErrorEvent
@@ -38,8 +37,8 @@ import java.util.UUID
 class PollAffiliateMailboxTest: WordSpec() {
     lateinit var osClient: OsClient
     lateinit var mailboxService: MailboxService
-    val signingKeyRef = ProvenanceKeyGenerator.generateKeyPair().let { DirectKeyRef(it.public, it.private) }
-    val encryptionKeyRef = ProvenanceKeyGenerator.generateKeyPair().let { DirectKeyRef(it.public, it.private) }
+    val signingKeyRef = ProvenanceKeyGenerator.generateKeyPair().let { DirectKeyRef(it) }
+    val encryptionKeyRef = ProvenanceKeyGenerator.generateKeyPair().let { DirectKeyRef(it) }
 
     override fun beforeTest(testCase: TestCase) {
         super.beforeTest(testCase)


### PR DESCRIPTION
I realized that there is only one place where we are needing to handle different types of KeyRefs differently, so I changed the interface around to allow us to compute the secret key on the KeyRef interface itself, allowing KeyRef to be un-sealed so that arbitrary implementations could be provided by a client