### PR TITLE
Allow for nullable constructor parameters in a hydration class

### DIFF
--- a/sdk/src/test/kotlin/io/provenance/scope/sdk/SDKTestHelper.kt
+++ b/sdk/src/test/kotlin/io/provenance/scope/sdk/SDKTestHelper.kt
@@ -7,6 +7,7 @@ import io.provenance.scope.contract.proto.Commons
 import io.provenance.scope.contract.proto.HelloWorldExample
 import io.provenance.scope.proto.PK
 import io.provenance.scope.contract.proto.Specifications
+import io.provenance.scope.contract.proto.TestContractProtos
 import io.provenance.scope.encryption.model.DirectKeyRef
 import io.provenance.scope.encryption.util.getAddress
 import io.provenance.scope.encryption.util.toJavaPrivateKey
@@ -121,5 +122,6 @@ fun createExistingScope(): ScopeResponse.Builder {
 }
 
 data class HelloWorldData(@AnnotationRecord(name = "record2") val name: HelloWorldExample.ExampleName) {}
+data class HelloWorldDataNullable(@AnnotationRecord(name = "record2") val name: HelloWorldExample.ExampleName, @AnnotationRecord(name = "nullableRecord") val nullableRecord: TestContractProtos.TestProto?) {}
 
 


### PR DESCRIPTION
- if a record is missing and the class doesn't allow a nullable value for a particular record, the value being passed in as null may result in an exception being thrown (i.e. an `InvocationTargetException` caused by `java.lang.NullPointerException: Parameter specified as non-null is null` in the case of a simple Kotlin data class)