### PR TITLE
Automate Maven Central Repository Closing

### DIFF
--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Publish to Maven Central
         run: |
-          ./gradlew publish \
+          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository \
             -Pversion=$VERSION \
             -Psigning.keyId=B7D30ABE -Psigning.password="${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}" -Psigning.secretKeyRingFile=$GITHUB_WORKSPACE/release.gpg \
             --info

--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Publish to Maven Central
         run: |
-          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository \
+          ./gradlew publishToSonatype $(if [ "${{github.event.release.prerelease}}" = "true" ]; then echo 'closeSonatypeStagingRepository'; else echo 'closeAndReleaseSonatypeStagingRepository'; fi) \
             -Pversion=$VERSION \
             -Psigning.keyId=B7D30ABE -Psigning.password="${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}" -Psigning.secretKeyRingFile=$GITHUB_WORKSPACE/release.gpg \
             --info

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,9 +25,6 @@ plugins {
     id("io.github.gradle-nexus.publish-plugin") version Version.nexusPublishPlugin
 }
 
-group = "io.provenance.scope"
-version = project.property("version")?.takeIf { it != "unspecified" } ?: "1.0-SNAPSHOT"
-
 nexusPublishing {
     repositories {
         sonatype {
@@ -40,6 +37,9 @@ nexusPublishing {
 }
 
 subprojects {
+    group = "io.provenance.scope"
+    version = project.property("version")?.takeIf { it != "unspecified" } ?: "1.0-SNAPSHOT"
+
     val subProjectName = name
 
     apply(plugin = "maven-publish")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,9 +36,15 @@ nexusPublishing {
     }
 }
 
+val scopeSdkGroup = "io.provenance.scope"
+val scopeSdkVersion = project.property("version")?.takeIf { it != "unspecified" } ?: "1.0-SNAPSHOT"
+
+group = scopeSdkGroup
+version = scopeSdkVersion
+
 subprojects {
-    group = "io.provenance.scope"
-    version = project.property("version")?.takeIf { it != "unspecified" } ?: "1.0-SNAPSHOT"
+    group = scopeSdkGroup
+    version = scopeSdkVersion
 
     val subProjectName = name
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@ nexusPublishing {
             snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
             username.set(findProject("ossrhUsername")?.toString() ?: System.getenv("OSSRH_USERNAME"))
             password.set(findProject("ossrhPassword")?.toString() ?: System.getenv("OSSRH_PASSWORD"))
+            stagingProfileId.set("3180ca260b82a7") // prevents querying for the staging profile id, performance optimization
         }
     }
 }

--- a/buildSrc/src/main/kotlin/Version.kt
+++ b/buildSrc/src/main/kotlin/Version.kt
@@ -1,5 +1,6 @@
 object Version {
     const val protobufPlugin = "0.8.16"
+    const val nexusPublishPlugin = "1.1.0"
 
     const val kotlin = "1.4.31"
     const val protobuf = "3.12.0"


### PR DESCRIPTION
Try using https://github.com/gradle-nexus/publish-plugin/ to automate maven central repository publishing

This is a new plugin that combines an older nexus publishing plugin and the staging release automation plugin, seems to be actively supported and the recommended way to go as of the beginning of this year