### PR TITLE
allow fallback to MemoryClassLoader in the case of a LinkageError

### DIFF
--- a/engine/src/main/kotlin/io/provenance/scope/classloader/MemoryClassLoader.kt
+++ b/engine/src/main/kotlin/io/provenance/scope/classloader/MemoryClassLoader.kt
@@ -71,7 +71,8 @@ class MemoryClassLoader(
         } catch (t: Throwable) {
             when (t) {
                 is ClassNotFoundException,
-                is NoClassDefFoundError -> {
+                is NoClassDefFoundError,
+                is LinkageError -> {
                     try {
                         when {
                             parentFirst -> findClass(name).also { loadedFromParent = false }


### PR DESCRIPTION
- If this happens, it seems reasonable to try loading whatever class from the other ClassLoader... it could still fail but that would be a different problem. This allows for situations (like contract validation is using currently), where the validation logic happens in a class that isn't listed in ContractHash.kt (because we have no knowledge of that class in order to list it in the bootstrapping plugin), so we can't predict that it should be loaded in the MemoryClassLoader