### PR TITLE
load minimum of classes from app classloader

### DIFF
--- a/contract-base/src/main/kotlin/io/provenance/scope/contract/annotations/P8EAnnotations.kt
+++ b/contract-base/src/main/kotlin/io/provenance/scope/contract/annotations/P8EAnnotations.kt
@@ -42,7 +42,7 @@ annotation class Participants(val roles: Array<PartyType>)
 annotation class ScopeSpecification(val names: Array<String>)
 
 /**
- * Declaritively specifies a scope specification definition. This must be associated with a subclass of
+ * Declaratively specifies a scope specification definition. This must be associated with a subclass of
  * P8eScopeSpecification.
  */
 @Target(AnnotationTarget.CLASS)


### PR DESCRIPTION
- Only load the classes needed for reflection, seems to basically equate to the various classes that we might reference directly in the reflection code around contract execution, as that could lead to weird mismatches between the reference in code and the object being worked on that is loaded from the MemoryClassLoader (i.e. inspecting an annotation on a class/function or casting a function result to a Message)
- Seems to allow the los validation contracts using an external Validator object to work properly