### PR TITLE
separate out signing/encryption key for session participants

### DIFF
--- a/sdk/src/main/kotlin/io/provenance/scope/sdk/Client.kt
+++ b/sdk/src/main/kotlin/io/provenance/scope/sdk/Client.kt
@@ -143,7 +143,7 @@ class Client(val inner: SharedClient, val affiliate: Affiliate) {
             .setContractSpec(contractSpec)
             .setProvenanceReference(contractRef)
             .setScope(scope)
-            .addParticipant(affiliate.partyType, affiliate.encryptionKeyRef.publicKey.toPublicKeyProto())
+            .addParticipant(affiliate.partyType, affiliate.signingKeyRef.publicKey, affiliate.encryptionKeyRef.publicKey)
             .addDataAccessKeys(scope.scope.scope.dataAccessList.map { inner.affiliateRepository.getAffiliateKeysByAddress(it).encryptionPublicKey })
     }
 
@@ -183,7 +183,7 @@ class Client(val inner: SharedClient, val affiliate: Affiliate) {
             .also { it.client = this } // TODO remove when class is moved over
             .setContractSpec(contractSpec)
             .setProvenanceReference(contractRef)
-            .addParticipant(affiliate.partyType, affiliate.encryptionKeyRef.publicKey.toPublicKeyProto())
+            .addParticipant(affiliate.partyType, affiliate.signingKeyRef.publicKey, affiliate.encryptionKeyRef.publicKey)
     }
 
     /**

--- a/sdk/src/test/kotlin/io/provenance/scope/sdk/SessionBuilderTest.kt
+++ b/sdk/src/test/kotlin/io/provenance/scope/sdk/SessionBuilderTest.kt
@@ -92,7 +92,7 @@ class SessionBuilderTest : WordSpec({
             builder.setContractSpec(
                 builder.contractSpec!!.toBuilder().addPartiesInvolved(Specifications.PartyType.AFFILIATE).build()
             )
-                .addParticipant(Specifications.PartyType.AFFILIATE, localKeys[2].public.toPublicKeyProto())
+                .addParticipant(Specifications.PartyType.AFFILIATE, localKeys[2].public, localKeys[2].public)
 
             val exampleName = HelloWorldExample.ExampleName.newBuilder().setFirstName("Test").build()
             builder.addProposedRecord("record2", exampleName)
@@ -124,7 +124,7 @@ class SessionBuilderTest : WordSpec({
             builder.setContractSpec(
                 builder.contractSpec!!.toBuilder().addPartiesInvolved(Specifications.PartyType.AFFILIATE).build()
             )
-                .addParticipant(Specifications.PartyType.AFFILIATE, localKeys[2].public.toPublicKeyProto())
+                .addParticipant(Specifications.PartyType.AFFILIATE, localKeys[2].public, localKeys[2].public)
 
             val exampleName = HelloWorldExample.ExampleName.newBuilder().setFirstName("Test").build()
             builder.addProposedRecord("record2", exampleName)
@@ -161,8 +161,8 @@ class SessionBuilderTest : WordSpec({
                 builder.setContractSpec(
                     builder.contractSpec!!.toBuilder().addPartiesInvolved(Specifications.PartyType.AFFILIATE).build()
                 )
-                    .addParticipant(Specifications.PartyType.AFFILIATE, localKeys[2].public.toPublicKeyProto())
-                    .addParticipant(Specifications.PartyType.AFFILIATE, localKeys[2].public.toPublicKeyProto())
+                    .addParticipant(Specifications.PartyType.AFFILIATE, localKeys[2].public, localKeys[2].public)
+                    .addParticipant(Specifications.PartyType.AFFILIATE, localKeys[2].public, localKeys[2].public)
             }
 
         }


### PR DESCRIPTION
- was previously using just the encryption key for both, which would screw up the isSigned calculation for participants with different signing/encryption keys
- fixed a couple misc warnings