### PR TITLE
cross-reference the addresses for the dataAccessList (sign vs. encrypt)

### DIFF
--- a/sdk/src/main/kotlin/io/provenance/scope/sdk/AffiliateRepository.kt
+++ b/sdk/src/main/kotlin/io/provenance/scope/sdk/AffiliateRepository.kt
@@ -41,5 +41,28 @@ class AffiliateRepository(private val mainNet: Boolean) {
      *
      * @return the [signing and encryption public keys][SigningAndEncryptionPublicKeys] of the affiliate
      */
-    fun getAffiliateKeysByAddress(affiliateAddress: String) = affiliateAddressToPublicKeys.get(affiliateAddress).orThrow { AffiliateNotFoundException("Affiliate with address $affiliateAddress not found") }
+    fun tryGetAffiliateKeysByAddress(affiliateAddress: String): SigningAndEncryptionPublicKeys? = affiliateAddressToPublicKeys.get(affiliateAddress)
+
+    /**
+     * Look up an affiliate's keys by address
+     *
+     * @param [affiliateAddress] the address of the affiliate. Note: this may be the address of either their signing or encryption public key
+     *
+     * @return the [signing and encryption public keys][SigningAndEncryptionPublicKeys] of the affiliate
+     */
+    fun getAffiliateKeysByAddress(affiliateAddress: String): SigningAndEncryptionPublicKeys = tryGetAffiliateKeysByAddress(affiliateAddress).orThrow { AffiliateNotFoundException("Affiliate with address $affiliateAddress not found") }
+
+    /**
+     * Look up the corresponding signing/encryption key address for an affiliate given a supplied signing/encryption address
+     *
+     * @param [affiliateAddress] the address of the affiliate. Note: this may be the address of either their signing or encryption public key
+     *
+     * @return the other address for this affiliate, if it exists
+     */
+    fun tryGetCorrespondingAffiliateAddress(affiliateAddress: String): String? = tryGetAffiliateKeysByAddress(affiliateAddress)?.let {
+        listOf(
+            it.signingPublicKey.getAddress(mainNet),
+            it.encryptionPublicKey.getAddress(mainNet)
+        )
+    }?.find { it != affiliateAddress }
 }

--- a/sdk/src/main/kotlin/io/provenance/scope/sdk/Client.kt
+++ b/sdk/src/main/kotlin/io/provenance/scope/sdk/Client.kt
@@ -200,7 +200,7 @@ class Client(val inner: SharedClient, val affiliate: Affiliate) {
      */
     fun execute(session: Session): ExecutionResult {
         val span = tracer.buildSpan("Execution").start().also { tracer.activateSpan(it) }
-        val input = session.packageContract(inner.config.mainNet)
+        val input = session.packageContract(inner.config.mainNet, inner.affiliateRepository)
         log.debug("Contract name: ${input.contract.definition.name}")
         log.debug("Session Id: ${session.sessionUuid}")
         log.debug("Execution UUID: ${input.executionUuid}")


### PR DESCRIPTION
- The old P8eMemorializeContract handler on the blockchain seems to be setting the dataAccessList to the address of the parties' signing key, when it is expected by the sdk to be the encryption key (as that is the key used to share data out to)... Fortunately the sdk can already look the affiliates up by either address to retrieve the registered encryption public key, so this just updates the check to be more flexible