### PR TITLE
Optional records

### DIFF
--- a/contract-base/src/main/kotlin/io/provenance/scope/contract/annotations/P8EAnnotations.kt
+++ b/contract-base/src/main/kotlin/io/provenance/scope/contract/annotations/P8EAnnotations.kt
@@ -21,6 +21,15 @@ annotation class Function(val invokedBy: PartyType)
 @MustBeDocumented
 annotation class Record(val name: String, val optional: Boolean = false)
 
+/**
+ * Allows skipping function execution if existing record is present. Note, the specified record must be
+ * supplied as an optional constructor record to use this functionality.
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+annotation class SkipIfRecordExists(val name: String)
+
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)
 @MustBeDocumented

--- a/contract-base/src/main/kotlin/io/provenance/scope/contract/annotations/P8EAnnotations.kt
+++ b/contract-base/src/main/kotlin/io/provenance/scope/contract/annotations/P8EAnnotations.kt
@@ -19,7 +19,7 @@ annotation class Function(val invokedBy: PartyType)
 @Target(AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
 @MustBeDocumented
-annotation class Record(val name: String)
+annotation class Record(val name: String, val optional: Boolean = false)
 
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)

--- a/contract-proto/src/main/proto/io/provenance/scope/contract/common.proto
+++ b/contract-proto/src/main/proto/io/provenance/scope/contract/common.proto
@@ -13,6 +13,7 @@ message DefinitionSpec {
     Location resource_location = 2;
     Signature signature = 3;
     Type type = 4;
+    bool optional = 5; // default is false
 
     enum Type {
         NO_DEF_TYPE = 0;

--- a/engine/src/main/kotlin/io/provenance/scope/ContractWrapper.kt
+++ b/engine/src/main/kotlin/io/provenance/scope/ContractWrapper.kt
@@ -13,7 +13,6 @@ import io.provenance.scope.objectstore.util.base64Decode
 import io.provenance.scope.util.orThrowContractDefinition
 import io.provenance.scope.util.toOffsetDateTime
 import io.provenance.scope.util.withoutLogging
-import org.bouncycastle.asn1.x500.style.RFC4519Style.name
 import java.lang.reflect.Constructor
 import java.lang.reflect.Method
 import java.lang.reflect.Parameter

--- a/sdk/src/main/kotlin/io/provenance/scope/sdk/ContractSpecMapper.kt
+++ b/sdk/src/main/kotlin/io/provenance/scope/sdk/ContractSpecMapper.kt
@@ -133,7 +133,8 @@ object ContractSpecMapper {
                                     erasedType.name,
                                     protoRef
                                 ),
-                                FACT_LIST
+                                FACT_LIST,
+                                optional = factAnnotation.optional
                             )
                         )
                     } else {
@@ -144,7 +145,8 @@ object ContractSpecMapper {
                                     param.type.javaType.typeName,
                                     protoRef
                                 ),
-                                FACT
+                                FACT,
+                                optional = factAnnotation.optional
                             )
                         )
                     }

--- a/sdk/src/main/kotlin/io/provenance/scope/sdk/SessionBuilder.kt
+++ b/sdk/src/main/kotlin/io/provenance/scope/sdk/SessionBuilder.kt
@@ -573,23 +573,25 @@ class Session(
             // TODO this can be optimized by checking the recitals and record groups and determining what subset, if any,
             // of input facts need to be fetched and stored in order only save the objects that are needed by some of
             // the recitals
-            contract.inputsList.map { record ->
-                with(client) {
-                    val hashBytes = record.dataLocation.ref.hash.base64Decode()
-                     val obj = inner.osClient.getJar(hashBytes, affiliate.encryptionKeyRef).get().readAllBytes()
-                    val inputStream = ByteArrayInputStream(obj)
+            contract.inputsList
+                .filter { record -> record.dataLocation.ref.hash.isNotBlank() }
+                .map { record ->
+                    with(client) {
+                        val hashBytes = record.dataLocation.ref.hash.base64Decode()
+                         val obj = inner.osClient.getJar(hashBytes, affiliate.encryptionKeyRef).get().readAllBytes()
+                        val inputStream = ByteArrayInputStream(obj)
 
-                    val loHash = hashBytes.size == 16
-                    val msgSha256 = obj.sha256()
-                    val useSha256 = if (loHash) {
-                        msgSha256.loBytes().toByteArray()
-                    } else {
-                        msgSha256
-                    }.contentEquals(hashBytes)
+                        val loHash = hashBytes.size == 16
+                        val msgSha256 = obj.sha256()
+                        val useSha256 = if (loHash) {
+                            msgSha256.loBytes().toByteArray()
+                        } else {
+                            msgSha256
+                        }.contentEquals(hashBytes)
 
-                     inner.osClient.putJar(inputStream, affiliate.signingKeyRef, affiliate.encryptionKeyRef, obj.size.toLong(), audience, sha256 = useSha256, loHash = loHash)
+                         inner.osClient.putJar(inputStream, affiliate.signingKeyRef, affiliate.encryptionKeyRef, obj.size.toLong(), audience, sha256 = useSha256, loHash = loHash)
+                    }
                 }
-            }
         }
 
         // TODO (steve) for later convert to async with ListenableFutures

--- a/util/src/main/kotlin/io/provenance/scope/util/ProtoUtil.kt
+++ b/util/src/main/kotlin/io/provenance/scope/util/ProtoUtil.kt
@@ -31,10 +31,11 @@ object ProtoJsonUtil {
 }
 
 object ProtoUtil {
-    fun defSpecBuilderOf(name: String, location: Location.Builder, type: Type): DefinitionSpec.Builder =
+    fun defSpecBuilderOf(name: String, location: Location.Builder, type: Type, optional: Boolean = false): DefinitionSpec.Builder =
         DefinitionSpec.newBuilder()
             .setName(name)
             .setType(type)
+            .setOptional(optional)
             .setResourceLocation(
                 location
             )


### PR DESCRIPTION
* Allow for dealing with records that may or may not already exist (i.e. append to an existing record if it exists, otherwise set fresh)
* Allow for skipping function execution if an optional record already exists (and you don't want to re-set it)