### PR TITLE
Make Client implement Closeable

### DIFF
--- a/examples/app/src/main/kotlin/io/provenance/scope/examples/app/BatchSendContracts.kt
+++ b/examples/app/src/main/kotlin/io/provenance/scope/examples/app/BatchSendContracts.kt
@@ -117,8 +117,8 @@ fun main(args: Array<String>) {
             println("Could not shutdown Provenance managed channel cleanly!")
         }
 
-        sdk.inner.close()
-        if (!sdk.inner.awaitTermination(10, TimeUnit.SECONDS)) {
+        sdk.close()
+        if (!sdk.awaitTermination(10, TimeUnit.SECONDS)) {
             println("Could not shutdown sdk managed channel cleanly!")
         }
     }

--- a/examples/app/src/main/kotlin/io/provenance/scope/examples/app/CreatePackageAndCheckIn.kt
+++ b/examples/app/src/main/kotlin/io/provenance/scope/examples/app/CreatePackageAndCheckIn.kt
@@ -145,8 +145,8 @@ fun main(args: Array<String>) {
             println("Could not shutdown Provenance managed channel cleanly!")
         }
 
-        sdk.inner.close()
-        if (!sdk.inner.awaitTermination(10, TimeUnit.SECONDS)) {
+        sdk.close()
+        if (!sdk.awaitTermination(10, TimeUnit.SECONDS)) {
             println("Could not shutdown sdk managed channel cleanly!")
         }
     }

--- a/examples/app/src/main/kotlin/io/provenance/scope/examples/app/DataAccess.kt
+++ b/examples/app/src/main/kotlin/io/provenance/scope/examples/app/DataAccess.kt
@@ -116,8 +116,8 @@ fun main(args: Array<String>) {
             println("Could not shutdown Provenance managed channel cleanly!")
         }
 
-        sdk.inner.close()
-        if (!sdk.inner.awaitTermination(10, TimeUnit.SECONDS)) {
+        sdk.close()
+        if (!sdk.awaitTermination(10, TimeUnit.SECONDS)) {
             println("Could not shutdown sdk managed channel cleanly!")
         }
     }

--- a/examples/app/src/main/kotlin/io/provenance/scope/examples/app/SimpleContract.kt
+++ b/examples/app/src/main/kotlin/io/provenance/scope/examples/app/SimpleContract.kt
@@ -100,8 +100,8 @@ fun main(args: Array<String>) {
             println("Could not shutdown Provenance managed channel cleanly!")
         }
 
-        sdk.inner.close()
-        if (!sdk.inner.awaitTermination(10, TimeUnit.SECONDS)) {
+        sdk.close()
+        if (!sdk.awaitTermination(10, TimeUnit.SECONDS)) {
             println("Could not shutdown sdk managed channel cleanly!")
         }
     }

--- a/examples/app/src/main/kotlin/io/provenance/scope/examples/app/SmartKeyHsm.kt
+++ b/examples/app/src/main/kotlin/io/provenance/scope/examples/app/SmartKeyHsm.kt
@@ -124,8 +124,8 @@ fun main(args: Array<String>) {
             println("Could not shutdown Provenance managed channel cleanly!")
         }
 
-        sdk.inner.close()
-        if (!sdk.inner.awaitTermination(10, TimeUnit.SECONDS)) {
+        sdk.close()
+        if (!sdk.awaitTermination(10, TimeUnit.SECONDS)) {
             println("Could not shutdown sdk managed channel cleanly!")
         }
     }

--- a/examples/app/src/main/kotlin/io/provenance/scope/examples/app/UpdateAndIndexContract.kt
+++ b/examples/app/src/main/kotlin/io/provenance/scope/examples/app/UpdateAndIndexContract.kt
@@ -260,8 +260,8 @@ fun main(args: Array<String>) {
             println("Could not shutdown Provenance managed channel cleanly!")
         }
 
-        sdk.inner.close()
-        if (!sdk.inner.awaitTermination(10, TimeUnit.SECONDS)) {
+        sdk.close()
+        if (!sdk.awaitTermination(10, TimeUnit.SECONDS)) {
             println("Could not shutdown sdk managed channel cleanly!")
         }
     }

--- a/sdk/src/main/kotlin/io/provenance/scope/sdk/Client.kt
+++ b/sdk/src/main/kotlin/io/provenance/scope/sdk/Client.kt
@@ -111,7 +111,7 @@ class SharedClient(val config: ClientConfig) : Closeable {
  * @property [inner] the base [SharedClient] instance containing configuration and shared resources
  * @property [affiliate] an object representing an affiliate with the appropriate keys for signing/encryption and the role of this affiliate on contracts
  */
-class Client(val inner: SharedClient, val affiliate: Affiliate) {
+class Client(val inner: SharedClient, val affiliate: Affiliate) : Closeable {
 
     private val log = LoggerFactory.getLogger(this::class.java);
     private val tracer = GlobalTracer.get()
@@ -421,4 +421,20 @@ class Client(val inner: SharedClient, val affiliate: Affiliate) {
     }
 
     private fun <T : Any, X : Throwable> T?.orThrow(supplier: () -> X) = this ?: throw supplier()
+
+    override fun close() {
+        inner.close()
+    }
+
+    /**
+     * Wait for all resources to properly close and be cleaned up. Should only be called after [close].
+     *
+     * @param [timeout] the timeout value, after which to give up on waiting
+     * @param [unit] the time unit corresponding to the [timeout] value
+     *
+     * @return whether the resources were fully terminated
+     */
+    fun awaitTermination(timeout: Long, unit: TimeUnit): Boolean {
+        return inner.awaitTermination(timeout, unit)
+    }
 }

--- a/sdk/src/test/kotlin/io/provenance/scope/sdk/ClientTest.kt
+++ b/sdk/src/test/kotlin/io/provenance/scope/sdk/ClientTest.kt
@@ -58,8 +58,8 @@ class ClientTest : WordSpec() {
         )
     ).also {
         cleanupHandlers.add {
-            it.inner.close()
-            it.inner.awaitTermination(1, TimeUnit.SECONDS)
+            it.close()
+            it.awaitTermination(1, TimeUnit.SECONDS)
         }
     }
 


### PR DESCRIPTION
### Context
This addresses #59
### Changes
In the same manner that `io.provenance.scope.sdk.SharedClient` handles its `CachedOsClient`, let `io.provenance.scope.sdk.Client`
- implement `java.io.Closeable` to close its `SharedClient` value
- expose an `awaitTermination` function to wait for the resource closing to succeed