### PR TITLE
Updating Envelope Message / Misc Mailbox Change

### DIFF
--- a/sdk/src/main/kotlin/io/provenance/scope/sdk/Client.kt
+++ b/sdk/src/main/kotlin/io/provenance/scope/sdk/Client.kt
@@ -44,7 +44,6 @@ import io.provenance.scope.encryption.util.toPublicKey
 import io.provenance.scope.util.AffiliateNotFoundException
 import io.provenance.scope.util.EnvelopeAlreadySignedException
 import io.provenance.scope.util.TypeUrls
-import io.provenance.scope.util.or
 import io.provenance.scope.util.setValue
 import java.time.OffsetDateTime
 import java.util.concurrent.ScheduledExecutorService
@@ -271,10 +270,11 @@ class Client(val inner: SharedClient, val affiliate: Affiliate) {
      *
      * @param [executor] a [ScheduledExecutorService] on which to poll for mail
      * @param [handler] a [MailHandlerFn] to receive incoming mail for this client's affiliate
+     * @param [rate] a [Long] rate (in seconds) at which the mailbox is polled mail. Default is 1 second.
      *
      * @return a [ScheduledFuture] that can be used to cancel the scheduled polling for this handler
      */
-    fun registerMailHandler(executor: ScheduledExecutorService, handler: MailHandlerFn): ScheduledFuture<*> =
+    fun registerMailHandler(executor: ScheduledExecutorService, rate: Long = 1, handler: MailHandlerFn): ScheduledFuture<*> =
         executor.scheduleAtFixedRate(PollAffiliateMailbox(
             inner.osClient,
             inner.mailboxService,
@@ -283,7 +283,7 @@ class Client(val inner: SharedClient, val affiliate: Affiliate) {
             maxResults = 100,
             inner.config.mainNet,
             handler
-        ), 1, 1, TimeUnit.SECONDS)
+        ), 1, rate, TimeUnit.SECONDS)
 
     /**
      * Submit an envelope to other contract parties for execution

--- a/sdk/src/main/kotlin/io/provenance/scope/sdk/Client.kt
+++ b/sdk/src/main/kotlin/io/provenance/scope/sdk/Client.kt
@@ -234,7 +234,7 @@ class Client(val inner: SharedClient, val affiliate: Affiliate) {
 
         return when (result.isSigned()) {
             true -> {
-                SignedResult(envelopeState, session).also { signedResult ->
+                SignedResult(envelopeState).also { signedResult ->
                     log.debug("Number of each type: ${signedResult.executionInfo.groupingBy { it.second }.eachCount()}")
                     log.debug("List of ID/Address ${signedResult.executionInfo.map { it.third + it.first }}")
                     log.trace("Full Content of TX Protos: ${signedResult.messages}")

--- a/sdk/src/main/kotlin/io/provenance/scope/sdk/Client.kt
+++ b/sdk/src/main/kotlin/io/provenance/scope/sdk/Client.kt
@@ -235,7 +235,7 @@ class Client(val inner: SharedClient, val affiliate: Affiliate) {
 
         return when (result.isSigned()) {
             true -> {
-                SignedResult(envelopeState).also { signedResult ->
+                SignedResult(envelopeState, session).also { signedResult ->
                     log.debug("Number of each type: ${signedResult.executionInfo.groupingBy { it.second }.eachCount()}")
                     log.debug("List of ID/Address ${signedResult.executionInfo.map { it.third + it.first }}")
                     log.trace("Full Content of TX Protos: ${signedResult.messages}")

--- a/sdk/src/main/kotlin/io/provenance/scope/sdk/ExecutionResult.kt
+++ b/sdk/src/main/kotlin/io/provenance/scope/sdk/ExecutionResult.kt
@@ -9,6 +9,7 @@ import io.provenance.metadata.v1.Party
 import io.provenance.metadata.v1.RecordInput
 import io.provenance.metadata.v1.RecordInputStatus
 import io.provenance.metadata.v1.RecordOutput
+import io.provenance.metadata.v1.ScopeResponse
 import io.provenance.scope.contract.proto.Contracts
 import io.provenance.scope.contract.proto.Envelopes.EnvelopeState
 import io.provenance.scope.encryption.ecies.ECUtils
@@ -29,7 +30,7 @@ sealed class ExecutionResult
  * @property [envelopeState] the resultant [EnvelopeState] from contract execution
  * @property [messages] a list of Provenance messages to package into a transaction for memorialization to chain
  */
-class SignedResult(val envelopeState: EnvelopeState, session: Session? = null) : ExecutionResult() {
+class SignedResult(val envelopeState: EnvelopeState) : ExecutionResult() {
     private val mainNet = envelopeState.result.mainNet
     private val signers = listOf(envelopeState.result.contract.invoker.signingPublicKey.publicKeyBytes.toByteArray().let { ECUtils.convertBytesToPublicKey(it).getAddress(mainNet) })
     private val parties = envelopeState.result.contract.recitalsList.map { Party.newBuilder()
@@ -44,22 +45,6 @@ class SignedResult(val envelopeState: EnvelopeState, session: Session? = null) :
     /** @suppress */
     val executionInfo = mutableListOf<Triple<String, String, String>>()
     val messages: List<Message> = mutableListOf<Message>().apply {
-
-        if (session?.scope != null) {
-
-            envelopeState.result.dataAccessList
-                .map { it.toPublicKey().getAddress(mainNet) }
-                .filter { address -> !session.scope.scope.scope.dataAccessList.contains(address) }
-                .takeIf { it.isNotEmpty() }?.let { addresses ->
-                    add(
-                        MsgAddScopeDataAccessRequest.newBuilder()
-                            .setScopeId(MetadataAddress.forScope(envelopeState.result.ref.scopeUuid.toUuid()).bytes.toByteString())
-                            .addAllDataAccess(addresses)
-                            .addAllSigners(signers)
-                            .build()
-                    )
-                }
-        }
 
         if (envelopeState.result.newScope) {
             val msgWriteScopeRequest = MsgWriteScopeRequest.newBuilder()
@@ -81,6 +66,20 @@ class SignedResult(val envelopeState: EnvelopeState, session: Session? = null) :
             add(
                 msgWriteScopeRequest
             )
+        } else {
+            val scope = envelopeState.result.scope.unpack(ScopeResponse::class.java)
+            envelopeState.result.dataAccessList
+                .map { it.toPublicKey().getAddress(mainNet) }
+                .filter { address -> !scope.scope.scope.dataAccessList.contains(address) }
+                .takeIf { it.isNotEmpty() }?.let { addresses ->
+                    add(
+                        MsgAddScopeDataAccessRequest.newBuilder()
+                            .setScopeId(MetadataAddress.forScope(envelopeState.result.ref.scopeUuid.toUuid()).bytes.toByteString())
+                            .addAllDataAccess(addresses)
+                            .addAllSigners(signers)
+                            .build()
+                    )
+                }
         }
 
         if (envelopeState.result.newSession) {

--- a/sdk/src/main/kotlin/io/provenance/scope/sdk/SessionBuilder.kt
+++ b/sdk/src/main/kotlin/io/provenance/scope/sdk/SessionBuilder.kt
@@ -471,15 +471,6 @@ class Session(
                  listOf(it.first to it.second, it.second to it.first)
              }.toMap()
 
-             sessionDataAccessAddresses.forEach { address ->
-                 if (!scope.scope.scope.dataAccessList.contains(address)) {
-                     val correspondingAddress = correspondingAddressLookup[address]
-                     if (correspondingAddress == null || !scope.scope.scope.dataAccessList.contains(correspondingAddress)) {
-                         throw IllegalStateException("$address was added with data access in this session but does not have access in the existing scope.")
-                     }
-                 }
-             }
-
              scope.scope.scope.dataAccessList.forEach { address ->
                  if (!sessionDataAccessAddresses.contains(address)) {
                      val correspondingAddress = correspondingAddressLookup[address]

--- a/sdk/src/test/kotlin/io/provenance/scope/sdk/ClientTest.kt
+++ b/sdk/src/test/kotlin/io/provenance/scope/sdk/ClientTest.kt
@@ -232,8 +232,8 @@ class ClientTest : WordSpec() {
                     .setScopeSpecUuid(UUID.randomUUID().toProtoUuid())
                     .setNewSession(true)
                     .addDataAccess(localKeys[2].public.toPublicKeyProto())
-                    .also {
-                        it.addAllDataAccess(dataAccessKeys)
+                    .also { builder ->
+                        dataAccessKeys?.let { builder.addAllDataAccess(it) }
                     }
                     .setRef(
                         Commons.ProvenanceReference.newBuilder()

--- a/sdk/src/test/kotlin/io/provenance/scope/sdk/SDKTestHelper.kt
+++ b/sdk/src/test/kotlin/io/provenance/scope/sdk/SDKTestHelper.kt
@@ -90,12 +90,12 @@ fun createSessionBuilderNoRecords(client: Client, existingScope: ScopeResponse? 
         .apply {
             if (existingScope != null) {
                 setScope(existingScope)
-                addDataAccessKey(localKeys[2].public)
+                addDataAccessKey(localKeys[1].public)
             }
         }
 }
 
-fun createExistingScope(affiliateRepository: AffiliateRepository = AffiliateRepository(false)): ScopeResponse.Builder {
+fun createExistingScope(affiliateRepository: AffiliateRepository = AffiliateRepository(false), ownerAddress: String? = null): ScopeResponse.Builder {
     val scopeUuid = UUID.randomUUID()
     val sessionUUID = UUID.randomUUID()
     val specificationUUID = UUID.randomUUID()
@@ -116,8 +116,15 @@ fun createExistingScope(affiliateRepository: AffiliateRepository = AffiliateRepo
     val ownerKey = ProvenanceKeyGenerator.generateKeyPair()
     affiliateRepository.addAffiliate(ownerKey.public, ownerKey.public)
     val scope = Scope.newBuilder()
-        .addDataAccess(localKeys[2].public.getAddress(false))
-        .addOwners(Party.newBuilder().setRole(PartyType.PARTY_TYPE_OWNER).setAddress(ownerKey.public.getAddress(false)))
+        .addDataAccess(localKeys[1].public.getAddress(false))
+        .addOwners(
+            Party.newBuilder()
+            .setRole(PartyType.PARTY_TYPE_OWNER)
+            .apply {
+                ownerAddress?.let { setAddress(it) }
+                    ?: setAddress(ownerKey.public.getAddress(false))
+            }
+        )
         .setScopeId(MetadataAddress.forScope(scopeUuid).bytes.toByteString())
         .setValueOwnerAddress("ownerAddress")
         .setSpecificationId(MetadataAddress.forScopeSpecification(specificationUUID).bytes.toByteString())

--- a/sdk/src/test/kotlin/io/provenance/scope/sdk/SDKTestHelper.kt
+++ b/sdk/src/test/kotlin/io/provenance/scope/sdk/SDKTestHelper.kt
@@ -114,7 +114,7 @@ fun createExistingScope(): ScopeResponse.Builder {
     val recordWrapper = RecordWrapper.newBuilder().setRecord(scopeRecord).build()
     val scope = Scope.newBuilder()
         .addDataAccess(localKeys[2].public.getAddress(false))
-        .addOwners(Party.newBuilder().setRole(PartyType.PARTY_TYPE_OWNER))
+        .addOwners(Party.newBuilder().setAddress(localKeys[2].public.getAddress(false)).setRole(PartyType.PARTY_TYPE_OWNER))
         .setScopeId(MetadataAddress.forScope(scopeUuid).bytes.toByteString())
         .setValueOwnerAddress("ownerAddress")
         .setSpecificationId(MetadataAddress.forScopeSpecification(specificationUUID).bytes.toByteString())

--- a/sdk/src/test/kotlin/io/provenance/scope/sdk/SessionBuilderTest.kt
+++ b/sdk/src/test/kotlin/io/provenance/scope/sdk/SessionBuilderTest.kt
@@ -279,30 +279,6 @@ class SessionBuilderTest : WordSpec({
             exception.message shouldBe "Provided scope must include records"
         }
 
-        "disallow setting data access keys that aren't on the existing scope" {
-            val sdkClient = createClientDummy(0)
-
-            val scopeResponse = createExistingScope().also { builder ->
-                builder.scopeBuilder.scopeBuilder
-                    .clearDataAccess()
-            }
-
-            val exampleName = HelloWorldExample.ExampleName.newBuilder().setFirstName("hello").build()
-
-            val builder = createSessionBuilderNoRecords(sdkClient, scopeResponse.build())
-
-            builder.addProposedRecord("record2", exampleName)
-            builder.dataAccessKeys.clear()
-            builder.addDataAccessKey(localKeys[2].public)
-
-            val session = builder.build()
-
-            val exception = shouldThrow<IllegalStateException> {
-                session.packageContract(false)
-            }
-            exception.message shouldContain localKeys[2].public.getAddress(false)
-        }
-
         "disallow data access keys on the existing scope that are omitted in the proposed session" {
             val sdkClient = createClientDummy(0)
 


### PR DESCRIPTION
- Removing the error checking for newly added participants on a contract execution for an existing scope where the new participants don't exist on the scope yet. Instead, automatically appending these new participants to a MsgAddScopeDataAccessRequest that the envelope returns to add them. 
- Minor change around the mailbox that allows configuration of the polling time. 