### PR TITLE
allow for hydration where all records are null

### DIFF
--- a/sdk/src/main/kotlin/io/provenance/scope/sdk/Client.kt
+++ b/sdk/src/main/kotlin/io/provenance/scope/sdk/Client.kt
@@ -383,13 +383,15 @@ class Client(val inner: SharedClient, val affiliate: Affiliate) : Closeable {
             .takeIf { it.isNotEmpty() }
             // TODO different error type?
             .orThrowContractDefinition("Unable to build POJO of type ${clazz.name} because not all constructor params implement ${Message::class.java.name} and have a \"Record\" annotation")
-            .firstOrNull {
-                it.parameters.any { param ->
-                    scope.recordsList.any { wrapper ->
-                        (wrapper.record.name == param.getAnnotation(Record::class.java)?.name &&
-                            wrapper.record.resultType() == param.type.name)
+            .run {
+                firstOrNull {
+                    it.parameters.any { param ->
+                        scope.recordsList.any { wrapper ->
+                            (wrapper.record.name == param.getAnnotation(Record::class.java)?.name &&
+                                wrapper.record.resultType() == param.type.name)
+                        }
                     }
-                }
+                } ?: firstOrNull()
             }
             .orThrowContractDefinition("No constructor params have a matching record in scope ${scope.uuid()}")
         val params = constructor.parameters

--- a/sdk/src/test/kotlin/io/provenance/scope/sdk/ClientTest.kt
+++ b/sdk/src/test/kotlin/io/provenance/scope/sdk/ClientTest.kt
@@ -153,6 +153,24 @@ class ClientTest : WordSpec() {
                 hydrateResponse.name.lastName shouldBe "TestLast"
                 hydrateResponse.nullableRecord shouldBe null
             }
+            "allow for null value when only record requested is not present and is nullable" {
+                val scope = createExistingScope().apply {
+                    scopeBuilder.scopeBuilder
+                        .clearDataAccess()
+                        .addDataAccess(encryptionKeyPair.public.getAddress(false))
+                }.clearRecords() // no records
+
+                val client = getClient()
+
+                client.inner.affiliateRepository.addAffiliate(
+                    signingPublicKey = signingKeyPair.public,
+                    encryptionPublicKey = encryptionKeyPair.public
+                )
+                val hydrateResponse = shouldNotThrowAny {
+                    client.hydrate(HelloWorldDataOnlyNullable::class.java, scope.build())
+                }
+                hydrateResponse.nullableRecord shouldBe null
+            }
         }
 
         "Client.execute" should {

--- a/sdk/src/test/kotlin/io/provenance/scope/sdk/SDKTestHelper.kt
+++ b/sdk/src/test/kotlin/io/provenance/scope/sdk/SDKTestHelper.kt
@@ -152,5 +152,8 @@ data class HelloWorldDataNullable(
     @AnnotationRecord(name = "record2") val name: HelloWorldExample.ExampleName,
     @AnnotationRecord(name = "nullableRecord") val nullableRecord: TestContractProtos.TestProto?
 ) {}
+data class HelloWorldDataOnlyNullable(
+    @AnnotationRecord(name = "nullableRecord") val nullableRecord: TestContractProtos.TestProto?
+) {}
 
 


### PR DESCRIPTION
* Previously this would error when all records attempting to be hydrated were null/not present in the scope. This was because the hydration logic would try and find a constructor that had at least one record that was present in the scope. This will fall back to selecting the first all-record-annotated constructor instead.