### PR TITLE
Api Key Ref + signer implementation

### DIFF
--- a/encryption/src/main/kotlin/io/provenance/scope/encryption/crypto/ApiSigner.kt
+++ b/encryption/src/main/kotlin/io/provenance/scope/encryption/crypto/ApiSigner.kt
@@ -1,0 +1,110 @@
+package io.provenance.scope.encryption.crypto
+
+import com.fortanix.sdkms.v1.model.DigestAlgorithm
+import com.fortanix.sdkms.v1.model.SignRequest
+import com.google.protobuf.ByteString
+import com.google.protobuf.Message
+import io.provenance.scope.encryption.crypto.SignerImpl.Companion.DEFAULT_HASH
+import io.provenance.scope.encryption.ecies.ECUtils
+import io.provenance.scope.encryption.util.orThrow
+import io.provenance.scope.proto.Common
+import io.provenance.scope.proto.PK
+import java.lang.IllegalStateException
+import java.security.MessageDigest
+import java.security.PublicKey
+import java.security.Security
+import java.security.Signature
+import java.util.Base64
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+
+class ApiSigner(
+    private val publicKey: PublicKey,
+    private val apiClient: ApiSignerClient,
+) : SignerImpl {
+    
+    init {
+        Security.addProvider(BouncyCastleProvider())
+    }
+    
+    override var hashType: SignerImpl.Companion.HashType = DEFAULT_HASH
+        set(value) {
+            field = value
+            resetDigest()
+        }
+    
+    private var messageDigest = MessageDigest.getInstance(hashType.value)
+    
+    private var signatureRequest: SignRequest? = null
+    
+    private fun resetDigest() {
+        messageDigest = MessageDigest.getInstance(hashType.value)
+    }
+
+    private val digestAlgorithm: DigestAlgorithm
+        get() = when(hashType) {
+            SignerImpl.Companion.HashType.SHA256 -> DigestAlgorithm.SHA256
+            SignerImpl.Companion.HashType.SHA512 -> DigestAlgorithm.SHA512
+        }
+
+    override var deterministic = true
+    
+    override fun sign(data: String) = sign(data.toByteArray())
+
+    override fun sign(data: Message) = sign(data.toByteArray())
+
+    override fun sign(data: ByteArray): Common.Signature {
+        val signature = apiClient.sign(data)
+        
+        return Common.Signature.newBuilder()
+            .setAlgo(signAlgorithm)
+            .setProvider(SignerImpl.PROVIDER)
+            .setSignature(String(Base64.getEncoder().encode(signature)))
+            .setSigner(signer())
+            .build()
+            .takeIf { verify(getPublicKey(), data, it) }
+            .orThrow { IllegalStateException("can't verify signature - public cert may not match private key.") }
+    }
+
+    override fun sign(): ByteArray {
+        signatureRequest?.hash = messageDigest.digest()
+        
+        return apiClient.sign(byteArrayOf())
+    }
+
+    override fun update(data: Byte) =
+        messageDigest.update(data)
+
+    override fun update(data: ByteArray) =
+        messageDigest.update(data)
+    
+    override fun update(data: ByteArray, off: Int, len: Int) =
+        messageDigest.update(data, off, len)
+    
+    override fun initSign() {
+        signatureRequest = SignRequest()
+            .hashAlg(digestAlgorithm)
+            .deterministicSignature(deterministic)
+            .hash(byteArrayOf())
+    }
+
+    override fun signer(): PK.SigningAndEncryptionPublicKeys =
+        PK.SigningAndEncryptionPublicKeys.newBuilder()
+            .setSigningPublicKey(PK.PublicKey.newBuilder()
+                .setCurve(PK.KeyCurve.SECP256K1)
+                .setType(PK.KeyType.ELLIPTIC)
+                .setPublicKeyBytes(
+                    ByteString.copyFrom(ECUtils.convertPublicKeyToBytes(getPublicKey())))
+                .setCompressed(false)
+                .build())
+            .build()
+    
+
+    override fun verify(publicKey: PublicKey, data: ByteArray, signature: Common.Signature): Boolean {
+        val s = Signature.getInstance(signature.algo, signature.provider)
+        s.initVerify(publicKey)
+        s.update(data)
+        return s.verify(Base64.getDecoder().decode(signature.signature))
+    }
+
+    override fun getPublicKey() = publicKey
+}

--- a/encryption/src/main/kotlin/io/provenance/scope/encryption/crypto/ApiSignerClient.kt
+++ b/encryption/src/main/kotlin/io/provenance/scope/encryption/crypto/ApiSignerClient.kt
@@ -1,0 +1,8 @@
+package io.provenance.scope.encryption.crypto
+
+import java.security.PublicKey
+
+interface ApiSignerClient {
+    fun sign(data: ByteArray): ByteArray
+    fun secretKey(ephemeralPublicKey: PublicKey): ByteArray
+}

--- a/encryption/src/main/kotlin/io/provenance/scope/encryption/model/Key.kt
+++ b/encryption/src/main/kotlin/io/provenance/scope/encryption/model/Key.kt
@@ -1,11 +1,12 @@
 package io.provenance.scope.encryption.model
 
 import com.fortanix.sdkms.v1.api.SignAndVerifyApi
+import io.provenance.scope.encryption.crypto.ApiSigner
+import io.provenance.scope.encryption.crypto.ApiSignerClient
 import io.provenance.scope.encryption.crypto.Pen
 import io.provenance.scope.encryption.crypto.SignerImpl
 import io.provenance.scope.encryption.crypto.SmartKeySigner
 import io.provenance.scope.encryption.ecies.ECUtils
-import io.provenance.scope.encryption.ecies.ProvenanceECIESCryptogram
 import io.provenance.scope.encryption.ecies.ProvenanceKeyGenerator
 import io.provenance.scope.encryption.experimental.extensions.toAgreeKey
 import io.provenance.scope.encryption.experimental.extensions.toTransientSecurityObject
@@ -60,6 +61,13 @@ class DirectKeyRef(publicKey: PublicKey, private val privateKey: PrivateKey) : K
     }
 
     override fun signer(): SignerImpl = Pen(KeyPair(publicKey, privateKey))
+}
+
+class ApiKeyRef(publicKey: PublicKey, private val apiSignerClient: ApiSignerClient): KeyRef(publicKey) {
+    override fun getSecretKey(ephemeralPublicKey: PublicKey) =
+        apiSignerClient.secretKey(publicKey)
+
+    override fun signer(): SignerImpl = ApiSigner(publicKey, apiSignerClient)
 }
 
 /**

--- a/sdk/src/main/kotlin/io/provenance/scope/sdk/ExecutionResult.kt
+++ b/sdk/src/main/kotlin/io/provenance/scope/sdk/ExecutionResult.kt
@@ -10,7 +10,6 @@ import io.provenance.metadata.v1.RecordInput
 import io.provenance.metadata.v1.RecordInputStatus
 import io.provenance.metadata.v1.RecordOutput
 import io.provenance.metadata.v1.ScopeResponse
-import io.provenance.metadata.v1.ValueOwnershipRequest
 import io.provenance.scope.contract.proto.Contracts
 import io.provenance.scope.contract.proto.Envelopes.EnvelopeState
 import io.provenance.scope.encryption.ecies.ECUtils

--- a/sdk/src/main/kotlin/io/provenance/scope/sdk/ExecutionResult.kt
+++ b/sdk/src/main/kotlin/io/provenance/scope/sdk/ExecutionResult.kt
@@ -10,6 +10,7 @@ import io.provenance.metadata.v1.RecordInput
 import io.provenance.metadata.v1.RecordInputStatus
 import io.provenance.metadata.v1.RecordOutput
 import io.provenance.metadata.v1.ScopeResponse
+import io.provenance.metadata.v1.ValueOwnershipRequest
 import io.provenance.scope.contract.proto.Contracts
 import io.provenance.scope.contract.proto.Envelopes.EnvelopeState
 import io.provenance.scope.encryption.ecies.ECUtils


### PR DESCRIPTION
## Overview

Creating a new Api Key Ref. This allows any third parties to pass in an implementation for `ApiSignerClient` connected to a custom rest api. Keystone implementation for this client is here: https://github.com/provenance-io/kms-connector/pull/7 

`ApiSigner` implementation is loosely based off `SmartKeySigner`, but a closer review by @piercetrey-figure or @jdfigure would be great :pls: 